### PR TITLE
Removed dollars from install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,10 @@ You can download latest debian packages from http://claudyus.github.io/LXC-Web-P
 
 ::
 
-  $ wget -O - http://claudyus.github.io/LXC-Web-Panel/claudyus.gpg.key | sudo apt-key add -
-  $ echo "deb http://claudyus.github.io/LXC-Web-Panel/ debian/" | sudo tee /etc/apt/sources.list.d/lwp.list
-  $ sudo apt-get update
-  $ sudo apt-get install lwp
+  wget -O - http://claudyus.github.io/LXC-Web-Panel/claudyus.gpg.key | sudo apt-key add -
+  echo "deb http://claudyus.github.io/LXC-Web-Panel/ debian/" | sudo tee /etc/apt/sources.list.d/lwp.list
+  sudo apt-get update
+  sudo apt-get install lwp
 
 Beware: The repository system was reorganize after the 0.6 release. See `this blog post <http://claudyus.github.io/LXC-Web-Panel/posts/02-reorganize-deb-repo.html>`_ for more information
 


### PR DESCRIPTION
No need to have $, it is clear that those are shell commands and it's easier to copy/paste commands without it.
