### PR TITLE
Fix for retrieving multiple (incorrect) ipv4 address

### DIFF
--- a/lwp/__init__.py
+++ b/lwp/__init__.py
@@ -237,7 +237,7 @@ def get_container_settings(name, status=None):
 
     # if ipv4 is unset try to determinate it
     if cfg['ipv4'] == '' and status == 'RUNNING':
-        cmd = ['lxc-ls --fancy --fancy-format name,ipv4|grep -w \'%s\' | awk \'{ print $2 }\'' % name]
+        cmd = ['lxc-ls --fancy --fancy-format name,ipv4|grep -w \'%s\\s\' | awk \'{ print $2 }\'' % name]
         try:
             cfg['ipv4'] = subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError:


### PR DESCRIPTION
For example:
I have containers called ```debian```, ```debian-2```, ```debian-3```, etc...
On the main dashboard it displays multiple ipv4 addresses for ```debian```. Actually it shows IP addresses of all of the containers which name contains ```debian```.

This is because grep search for only the name. I've added a plus whitespace, see the diff.

IMHO, the ultimate solution would be if that bash magic would be removed, and the output would be parsed in python.

Best regards,
susu