### PR TITLE
Feat: Show memory label colors as percentile when CT's memlimit is set

### DIFF
--- a/lwp/templates/index.html
+++ b/lwp/templates/index.html
@@ -132,21 +132,32 @@
                         } else {
                             el.text(data[i].memusg + " / " + data[i].settings.memlimit + ' MB');
                         }
-                        el[0].className = el[0].className.replace(/label\-(success|warning|important)/g,'label-'+memory_color(data[i].memusg));
+                        el[0].className = el[0].className.replace(/label\-(success|warning|important)/g,'label-'+memory_color(data[i].memusg, data[i].settings.memlimit));
                     }
                 });
 
                 $('#home-load').fadeOut();
             }
 
-            function memory_color(value){
-                if(value != 0)
-                    if ('0' <= value && value <= '512')
+            function memory_color(value, total){
+                if(total == '') {
+                    if(value != 0)
+                        if ('0' <= value && value <= '512')
+                            return 'success';
+                        else if ('512' <= value && value < '1024')
+                            return 'warning';
+                        else
+                            return 'important';
+                }
+                else {
+                    value = value / total;
+                    if (0 <= value && value <= 0.6)
                          return 'success';
-                    else if ('512' <= value && value < '1024')
+                    else if (0.6 <= value && value < 0.8)
                         return 'warning';
                     else
                         return 'important';
+                }
             }
 
             function refresh(){


### PR DESCRIPTION
Hi,

I suggest the following PR, to show the memory color indicators correctly when the container's memory limit is set. Currently is set to 512/1024MB limit and since containers can have arbitrary memory limits, it's good to have this feature.

Regards.